### PR TITLE
Change Inclusion Data format

### DIFF
--- a/src/blob_info.rs
+++ b/src/blob_info.rs
@@ -117,10 +117,10 @@ impl BlobHeader {
             .map(|quorum| Token::Tuple(quorum.into_tokens()))
             .collect();
 
-        vec![
+        vec![Token::Tuple(vec![
             Token::Tuple(commitment),
             data_length,
-            Token::Array(blob_quorum_params),
+            Token::Array(blob_quorum_params)])
         ]
     }
 }

--- a/src/blob_info.rs
+++ b/src/blob_info.rs
@@ -31,7 +31,7 @@ impl From<DisperserG1Commitment> for G1Commitment {
 }
 
 impl G1Commitment {
-    fn into_tokens(&self) -> Vec<Token> {
+    fn to_tokens(&self) -> Vec<Token> {
         let x = Token::Uint(U256::from_big_endian(&self.x));
         let y = Token::Uint(U256::from_big_endian(&self.y));
 
@@ -61,7 +61,7 @@ impl From<DisperserBlobQuorumParam> for BlobQuorumParam {
 }
 
 impl BlobQuorumParam {
-    fn into_tokens(self) -> Vec<Token> {
+    fn to_tokens(&self) -> Vec<Token> {
         let quorum_number = Token::Uint(U256::from(self.quorum_number));
         let adversary_threshold_percentage =
             Token::Uint(U256::from(self.adversary_threshold_percentage));
@@ -108,20 +108,21 @@ impl TryFrom<DisperserBlobHeader> for BlobHeader {
 }
 
 impl BlobHeader {
-    pub fn into_tokens(self) -> Vec<Token> {
-        let commitment = self.commitment.into_tokens();
+    pub fn to_tokens(&self) -> Vec<Token> {
+        let commitment = self.commitment.to_tokens();
         let data_length = Token::Uint(U256::from(self.data_length));
         let blob_quorum_params = self
             .blob_quorum_params
+            .clone()
             .into_iter()
-            .map(|quorum| Token::Tuple(quorum.into_tokens()))
+            .map(|quorum| Token::Tuple(quorum.to_tokens()))
             .collect();
 
         vec![Token::Tuple(vec![
             Token::Tuple(commitment),
             data_length,
-            Token::Array(blob_quorum_params)])
-        ]
+            Token::Array(blob_quorum_params),
+        ])]
     }
 }
 

--- a/src/client_tests.rs
+++ b/src/client_tests.rs
@@ -111,7 +111,7 @@ mod tests {
         let blob_info = get_blob_info(&client, &result).await.unwrap();
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert_eq!(expected_inclusion_data, actual_inclusion_data);
+        assert!(actual_inclusion_data.windows(expected_inclusion_data.len()).any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
         let retrieved_data = client.get_blob_data(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }

--- a/src/client_tests.rs
+++ b/src/client_tests.rs
@@ -7,10 +7,12 @@ mod tests {
     use std::{str::FromStr, time::Duration};
 
     use crate::{
-        client::GetBlobData, config::{EigenConfig, EigenSecrets, PrivateKey}, errors::{CommunicationError, EigenClientError}, merkle_proof_input::MerkleProofInput, EigenClient
+        client::GetBlobData,
+        config::{EigenConfig, EigenSecrets, PrivateKey},
+        errors::{CommunicationError, EigenClientError},
+        EigenClient,
     };
     use backon::{ConstantBuilder, Retryable};
-    use ethabi::Token;
     use serial_test::serial;
 
     use crate::blob_info::BlobInfo;
@@ -109,7 +111,9 @@ mod tests {
         let blob_info = get_blob_info(&client, &result).await.unwrap();
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert!(actual_inclusion_data.windows(expected_inclusion_data.len()).any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
+        assert!(actual_inclusion_data
+            .windows(expected_inclusion_data.len())
+            .any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
         let retrieved_data = client.get_blob_data(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }
@@ -143,7 +147,9 @@ mod tests {
 
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert!(actual_inclusion_data.windows(expected_inclusion_data.len()).any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
+        assert!(actual_inclusion_data
+            .windows(expected_inclusion_data.len())
+            .any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
         let retrieved_data = client.get_blob_data(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }
@@ -177,7 +183,9 @@ mod tests {
 
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert!(actual_inclusion_data.windows(expected_inclusion_data.len()).any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
+        assert!(actual_inclusion_data
+            .windows(expected_inclusion_data.len())
+            .any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
         let retrieved_data = client.get_blob_data(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }
@@ -211,7 +219,9 @@ mod tests {
 
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert!(actual_inclusion_data.windows(expected_inclusion_data.len()).any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
+        assert!(actual_inclusion_data
+            .windows(expected_inclusion_data.len())
+            .any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
         let retrieved_data = client.get_blob_data(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }
@@ -245,7 +255,9 @@ mod tests {
 
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert!(actual_inclusion_data.windows(expected_inclusion_data.len()).any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
+        assert!(actual_inclusion_data
+            .windows(expected_inclusion_data.len())
+            .any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
         let retrieved_data = client.get_blob_data(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }

--- a/src/client_tests.rs
+++ b/src/client_tests.rs
@@ -7,12 +7,10 @@ mod tests {
     use std::{str::FromStr, time::Duration};
 
     use crate::{
-        client::GetBlobData,
-        config::{EigenConfig, EigenSecrets, PrivateKey},
-        errors::{CommunicationError, EigenClientError},
-        EigenClient,
+        client::GetBlobData, config::{EigenConfig, EigenSecrets, PrivateKey}, errors::{CommunicationError, EigenClientError}, merkle_proof_input::MerkleProofInput, EigenClient
     };
     use backon::{ConstantBuilder, Retryable};
+    use ethabi::Token;
     use serial_test::serial;
 
     use crate::blob_info::BlobInfo;
@@ -145,7 +143,7 @@ mod tests {
 
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert_eq!(expected_inclusion_data, actual_inclusion_data);
+        assert!(actual_inclusion_data.windows(expected_inclusion_data.len()).any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
         let retrieved_data = client.get_blob_data(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }
@@ -179,7 +177,7 @@ mod tests {
 
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert_eq!(expected_inclusion_data, actual_inclusion_data);
+        assert!(actual_inclusion_data.windows(expected_inclusion_data.len()).any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
         let retrieved_data = client.get_blob_data(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }
@@ -213,7 +211,7 @@ mod tests {
 
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert_eq!(expected_inclusion_data, actual_inclusion_data);
+        assert!(actual_inclusion_data.windows(expected_inclusion_data.len()).any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
         let retrieved_data = client.get_blob_data(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }
@@ -247,7 +245,7 @@ mod tests {
 
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert_eq!(expected_inclusion_data, actual_inclusion_data);
+        assert!(actual_inclusion_data.windows(expected_inclusion_data.len()).any(|window| window == expected_inclusion_data)); //TODO: maybe get the actual inclusion data
         let retrieved_data = client.get_blob_data(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,10 @@ pub(crate) mod client_tests;
 pub mod config;
 pub mod errors;
 pub(crate) mod eth_client;
+pub(crate) mod merkle_proof_input;
 pub(crate) mod sdk;
 pub(crate) mod verifier;
 pub(crate) mod verifier_tests;
-pub(crate) mod merkle_proof_input;
 
 pub use self::client::EigenClient;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub(crate) mod eth_client;
 pub(crate) mod sdk;
 pub(crate) mod verifier;
 pub(crate) mod verifier_tests;
+pub(crate) mod merkle_proof_input;
 
 pub use self::client::EigenClient;
 

--- a/src/merkle_proof_input.rs
+++ b/src/merkle_proof_input.rs
@@ -9,12 +9,12 @@ pub(crate) struct MerkleProofInput {
 }
 
 impl MerkleProofInput {
-    pub(crate) fn into_tokens(&self) -> Vec<Token> {
-        vec![ Token::Tuple( vec![
+    pub(crate) fn to_tokens(&self) -> Vec<Token> {
+        vec![Token::Tuple(vec![
             Token::FixedBytes(self.batch_root.to_vec()),
             Token::FixedBytes(self.leaf.to_vec()),
-            Token::Uint(self.index.clone()),
-            Token::Bytes(self.inclusion_proof.clone())])
-        ]
+            Token::Uint(self.index),
+            Token::Bytes(self.inclusion_proof.clone()),
+        ])]
     }
 }

--- a/src/merkle_proof_input.rs
+++ b/src/merkle_proof_input.rs
@@ -1,0 +1,20 @@
+use ethabi::Token;
+use ethereum_types::U256;
+
+pub(crate) struct MerkleProofInput {
+    pub(crate) batch_root: [u8; 32],
+    pub(crate) leaf: [u8; 32],
+    pub(crate) index: U256,
+    pub(crate) inclusion_proof: Vec<u8>,
+}
+
+impl MerkleProofInput {
+    pub(crate) fn into_tokens(&self) -> Vec<Token> {
+        vec![ Token::Tuple( vec![
+            Token::FixedBytes(self.batch_root.to_vec()),
+            Token::FixedBytes(self.leaf.to_vec()),
+            Token::Uint(self.index.clone()),
+            Token::Bytes(self.inclusion_proof.clone())])
+        ]
+    }
+}

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -17,8 +17,10 @@ use crate::{
         AuthenticatedReply, BlobAuthHeader,
     },
     errors::{
-        BlobStatusError, CommunicationError, ConfigError, ConversionError, EigenClientError, VerificationError
-    }, merkle_proof_input::MerkleProofInput,
+        BlobStatusError, CommunicationError, ConfigError, ConversionError, EigenClientError,
+        VerificationError,
+    },
+    merkle_proof_input::MerkleProofInput,
 };
 use byteorder::{BigEndian, ByteOrder};
 use ethereum_types::Address;
@@ -238,13 +240,21 @@ impl RawEigenClient {
     ) -> Result<Option<Vec<u8>>, EigenClientError> {
         let blob_info = self.get_commitment(request_id).await?;
         if let Some(blob_info) = blob_info {
-            let inclusion_data = MerkleProofInput{
-                batch_root: blob_info.blob_verification_proof.batch_medatada.batch_header.batch_root.try_into().map_err(|_| ConversionError::NotPresent("a".to_string()))?,
-                leaf: self.keccak256(&self.keccak256(&ethabi::encode(&blob_info.blob_header.into_tokens()))),
+            let inclusion_data = MerkleProofInput {
+                batch_root: blob_info
+                    .blob_verification_proof
+                    .batch_medatada
+                    .batch_header
+                    .batch_root
+                    .try_into()
+                    .map_err(|_| ConversionError::NotPresent("a".to_string()))?,
+                leaf: self.keccak256(
+                    &self.keccak256(&ethabi::encode(&blob_info.blob_header.to_tokens())),
+                ),
                 index: blob_info.blob_verification_proof.blob_index.into(),
                 inclusion_proof: blob_info.blob_verification_proof.inclusion_proof,
             };
-            Ok(Some(ethabi::encode(&inclusion_data.into_tokens())))
+            Ok(Some(ethabi::encode(&inclusion_data.to_tokens())))
         } else {
             Ok(None)
         }


### PR DESCRIPTION
This PR changes Inclusion Data format to the abi encoded MerkleProofInput.
This change is needed to verify the merkle proof on M1.